### PR TITLE
IS-20975 Update dependency to comply with Google

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'net.zetetic:android-database-sqlcipher:3.5.9@aar'
+    implementation "net.zetetic:android-database-sqlcipher:4.5.4"
+    implementation "androidx.sqlite:sqlite:2.1.0"
 }


### PR DESCRIPTION
To comply with Google policies, this PR updates a deprecated dependency:

[IS-20975](https://wazoku.atlassian.net/browse/IS-20975)

[IS-20975]: https://wazoku.atlassian.net/browse/IS-20975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ